### PR TITLE
add gpu id option in training.py

### DIFF
--- a/training.py
+++ b/training.py
@@ -77,9 +77,9 @@ def train(
     args = parse_arguments()
 
     if torch.cuda.is_available():
-        device = torch.cuda.device(args.gpu_id)
+        device = torch.device(f'cuda:{args.gpu_id}')
     else:
-        device = "cpu"
+        device = torch.device('cpu')
 
     print(f'Current Device: {device}')
 

--- a/training.py
+++ b/training.py
@@ -73,15 +73,8 @@ def train(
     writer,
     epochs,
     save_after,
+    device
 ):
-    args = parse_arguments()
-
-    if torch.cuda.is_available():
-        device = torch.device(f'cuda:{args.gpu_id}')
-    else:
-        device = torch.device('cpu')
-
-    print(f'Current Device: {device}')
 
     model = model.to(device)
 
@@ -209,6 +202,14 @@ def run():
     data_loader_training = DataLoader(trainingdata, batch_size=8, shuffle=True)
     data_loader_val = DataLoader(validationdata, batch_size=8, shuffle=True)
 
+    # device setting for training
+    if torch.cuda.is_available():
+        device = torch.device(f'cuda:{args.gpu_id}')
+    else:
+        device = torch.device('cpu')
+
+    print(f'Current Device: {device}\n')
+
     # Initialize the model
     model = Model()
     restart_from_checkpoint = False
@@ -222,9 +223,7 @@ def run():
     for nom, param in model.named_parameters():
         # print (nom, param.data.shape)
         parameters_tot += torch.prod(torch.tensor(param.data.shape))
-    print()
-    print("Number of model parameters {}".format(parameters_tot))
-    print()
+    print("Number of model parameters {}\n".format(parameters_tot))
 
     # define the loss function for the model training.
     criterion = torch.nn.BCELoss()
@@ -259,6 +258,7 @@ def run():
         writer,
         epochs=100,
         save_after=1,
+        device=device
     )
     writer.close()
 

--- a/training.py
+++ b/training.py
@@ -29,12 +29,20 @@ def parse_arguments():
         help="log path",
     )
 
+    group_gpus = parser.add_mutually_exclusive_group()
+    group_gpus.add_argument(
+        '--gpu-id',
+        type=int,
+        default=0,
+        help='id of gpu to use '
+        '(only applicable to non-distributed training)')
+
     parsed_arguments = parser.parse_args()
 
     # create log dir if it doesn't exists
     if not os.path.exists(parsed_arguments.log_path):
         os.mkdir(parsed_arguments.log_path)
-    
+
     dir_run = sorted(
         [
             filename
@@ -42,6 +50,7 @@ def parse_arguments():
             if filename.startswith("run_")
         ]
     )
+
     if len(dir_run) > 0:
         num_run = int(dir_run[-1].split("_")[-1]) + 1
     else:
@@ -65,10 +74,15 @@ def train(
     epochs,
     save_after,
 ):
+    args = parse_arguments()
+
     if torch.cuda.is_available():
-        device = "cuda"
+        device = torch.cuda.device(args.gpu_id)
     else:
         device = "cpu"
+
+    print(f'Current Device: {device}')
+
     model = model.to(device)
 
     tool4metric = ConfuseMatrixMeter(n_class=2)
@@ -86,7 +100,8 @@ def train(
         it_loss = criterion(generated_mask, mask)
 
         # Feeding the comparison metric tool:
-        bin_genmask = (generated_mask.to("cpu") > 0.5).detach().numpy().astype(int)
+        bin_genmask = (generated_mask.to("cpu") >
+                       0.5).detach().numpy().astype(int)
         mask = mask.to("cpu").numpy().astype(int)
         tool4metric.update_cm(pr=bin_genmask, gt=mask)
 
@@ -117,15 +132,18 @@ def train(
         print("Loss for epoch {} is {}".format(epc, epoch_loss))
         writer.add_scalar("Loss/epoch", epoch_loss, epc)
         scores_dictionary = tool4metric.get_scores()
-        writer.add_scalar("IoU class change/epoch", scores_dictionary["iou_1"], epc)
-        writer.add_scalar("F1 class change/epoch", scores_dictionary["F1_1"], epc)
+        writer.add_scalar("IoU class change/epoch",
+                          scores_dictionary["iou_1"], epc)
+        writer.add_scalar("F1 class change/epoch",
+                          scores_dictionary["F1_1"], epc)
         print(
             "IoU class change for epoch {} is {}".format(
                 epc, scores_dictionary["iou_1"]
             )
         )
         print(
-            "F1 class change for epoch {} is {}".format(epc, scores_dictionary["F1_1"])
+            "F1 class change for epoch {} is {}".format(
+                epc, scores_dictionary["F1_1"])
         )
         print()
         writer.flush()
@@ -142,29 +160,33 @@ def train(
         tool4metric.clear()
         with torch.no_grad():
             for (reference, testimg), mask in dataset_val:
-                epoch_loss_eval += evaluate(reference, testimg, mask).to("cpu").numpy()
+                epoch_loss_eval += evaluate(reference,
+                                            testimg, mask).to("cpu").numpy()
 
         epoch_loss_eval /= len(dataset_val)
         print("Validation phase summary")
         print("Loss for epoch {} is {}".format(epc, epoch_loss_eval))
         writer.add_scalar("Loss_val/epoch", epoch_loss_eval, epc)
         scores_dictionary = tool4metric.get_scores()
-        writer.add_scalar("IoU_val class change/epoch", scores_dictionary["iou_1"], epc)
-        writer.add_scalar("F1_val class change/epoch", scores_dictionary["F1_1"], epc)
+        writer.add_scalar("IoU_val class change/epoch",
+                          scores_dictionary["iou_1"], epc)
+        writer.add_scalar("F1_val class change/epoch",
+                          scores_dictionary["F1_1"], epc)
         print(
             "IoU class change for epoch {} is {}".format(
                 epc, scores_dictionary["iou_1"]
             )
         )
         print(
-            "F1 class change for epoch {} is {}".format(epc, scores_dictionary["F1_1"])
+            "F1 class change for epoch {} is {}".format(
+                epc, scores_dictionary["F1_1"])
         )
         print()
 
     for epc in range(epochs):
         training_phase(epc)
         validation_phase(epc)
-        # scheduler step 
+        # scheduler step
         scheduler.step()
 
 
@@ -209,16 +231,16 @@ def run():
 
     # choose the optimizer in view of the used dataset
     # Optimizer with tuned parameters for LEVIR-CD
-    optimizer = torch.optim.AdamW(model.parameters(), lr=0.00356799066427741, 
-                                    weight_decay=0.009449677083344786, amsgrad=False)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=0.00356799066427741,
+                                  weight_decay=0.009449677083344786, amsgrad=False)
 
-    # Optimizer with tuned parameters for WHU-CD                               
-    # optimizer = torch.optim.AdamW(model.parameters(), lr=0.002596776436816101, 
+    # Optimizer with tuned parameters for WHU-CD
+    # optimizer = torch.optim.AdamW(model.parameters(), lr=0.002596776436816101,
     #                                 weight_decay=0.008620171028843307, amsgrad=False)
 
     # scheduler for the lr of the optimizer
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer,T_max=100)
-
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=100)
 
     # copy the configurations
     _ = shutil.copytree(


### PR DESCRIPTION
For in case of having multiple GPU devices, I added an option to use the GPU of a specific id. 
The default value of this option is 0 so that learning could be performed using the first (detected) GPU when executed without specifying this option.